### PR TITLE
support UserSpaceOnUse and objMatrix transform of its points according to object's current transform

### DIFF
--- a/gradient.go
+++ b/gradient.go
@@ -4,6 +4,7 @@
 package rasterx
 
 import (
+	"image"
 	"image/color"
 	"math"
 	"sort"
@@ -34,7 +35,7 @@ type (
 
 	Gradient struct {
 		Points   [5]float64
-		Stops    []GradStop
+		Stops    []*GradStop
 		Bounds   struct{ X, Y, W, H float64 }
 		Matrix   Matrix2D
 		Spread   SpreadMethod
@@ -77,7 +78,7 @@ func (g *Gradient) tColor(t, opacity float64) color.Color {
 	}
 	switch g.Spread {
 	case RepeatSpread:
-		var s1, s2 GradStop
+		var s1, s2 *GradStop
 		switch place {
 		case 0, d:
 			s1, s2 = g.Stops[d-1], g.Stops[0]
@@ -123,7 +124,7 @@ func (g *Gradient) tColor(t, opacity float64) color.Color {
 	}
 }
 
-func (g *Gradient) blendStops(t, opacity float64, s1, s2 GradStop, flip bool) color.Color {
+func (g *Gradient) blendStops(t, opacity float64, s1, s2 *GradStop, flip bool) color.Color {
 	s1off := s1.Offset
 	if s1.Offset > s2.Offset && !flip { // happens in repeat spread mode
 		s1off -= 1
@@ -241,4 +242,13 @@ func (g *Gradient) GetColorFunction(opacity float64) interface{} {
 			return g.tColor((dx*dfx+dy*dfy)/d, opacity)
 		})
 	}
+}
+
+// SetBounds sets bounds of the gradient from standard image Rectangle
+func (g *Gradient) SetBounds(bounds image.Rectangle) {
+	g.Bounds.X = float64(bounds.Min.X)
+	g.Bounds.Y = float64(bounds.Min.Y)
+	sz := bounds.Size()
+	g.Bounds.W = float64(sz.X)
+	g.Bounds.H = float64(sz.Y)
 }

--- a/gradient.go
+++ b/gradient.go
@@ -4,7 +4,6 @@
 package rasterx
 
 import (
-	"image"
 	"image/color"
 	"math"
 	"sort"
@@ -35,7 +34,7 @@ type (
 
 	Gradient struct {
 		Points   [5]float64
-		Stops    []*GradStop
+		Stops    []GradStop
 		Bounds   struct{ X, Y, W, H float64 }
 		Matrix   Matrix2D
 		Spread   SpreadMethod
@@ -78,7 +77,7 @@ func (g *Gradient) tColor(t, opacity float64) color.Color {
 	}
 	switch g.Spread {
 	case RepeatSpread:
-		var s1, s2 *GradStop
+		var s1, s2 GradStop
 		switch place {
 		case 0, d:
 			s1, s2 = g.Stops[d-1], g.Stops[0]
@@ -124,7 +123,7 @@ func (g *Gradient) tColor(t, opacity float64) color.Color {
 	}
 }
 
-func (g *Gradient) blendStops(t, opacity float64, s1, s2 *GradStop, flip bool) color.Color {
+func (g *Gradient) blendStops(t, opacity float64, s1, s2 GradStop, flip bool) color.Color {
 	s1off := s1.Offset
 	if s1.Offset > s2.Offset && !flip { // happens in repeat spread mode
 		s1off -= 1
@@ -242,13 +241,4 @@ func (g *Gradient) GetColorFunction(opacity float64) interface{} {
 			return g.tColor((dx*dfx+dy*dfy)/d, opacity)
 		})
 	}
-}
-
-// SetBounds sets bounds of the gradient from standard image Rectangle
-func (g *Gradient) SetBounds(bounds image.Rectangle) {
-	g.Bounds.X = float64(bounds.Min.X)
-	g.Bounds.Y = float64(bounds.Min.Y)
-	sz := bounds.Size()
-	g.Bounds.W = float64(sz.X)
-	g.Bounds.H = float64(sz.Y)
 }

--- a/gradient.go
+++ b/gradient.go
@@ -161,6 +161,11 @@ func (g *Gradient) GetColorFunction(opacity float64, objMatrix Matrix2D) interfa
 		return g.Stops[i].Offset < g.Stops[j].Offset
 	})
 
+	w, h := float64(g.Bounds.W), float64(g.Bounds.H)
+	oriX, oriY := float64(g.Bounds.X), float64(g.Bounds.Y)
+	gradT := Identity.Translate(oriX, oriY).Scale(w, h).
+		Mult(g.Matrix).Scale(1/w, 1/h).Translate(-oriX, -oriY).Invert()
+
 	if g.IsRadial {
 		cx, cy, fx, fy, rx, ry := g.Points[0], g.Points[1], g.Points[2], g.Points[3], g.Points[4], g.Points[4]
 		if g.Units == ObjectBoundingBox {
@@ -170,8 +175,6 @@ func (g *Gradient) GetColorFunction(opacity float64, objMatrix Matrix2D) interfa
 			fy = g.Bounds.Y + g.Bounds.H*fy
 			rx *= g.Bounds.W
 			ry *= g.Bounds.H
-			cx, cy = g.Matrix.Transform(cx, cy)
-			rx, ry = g.Matrix.TransformVector(rx, ry)
 		} else {
 			cx, cy = g.Matrix.Transform(cx, cy)
 			rx, ry = g.Matrix.TransformVector(rx, ry)
@@ -183,13 +186,22 @@ func (g *Gradient) GetColorFunction(opacity float64, objMatrix Matrix2D) interfa
 			// When the focus and center are the same things are much simpler;
 			// t is just distance from center
 			// scaled by the bounds aspect ratio times r
-			return ColorFunc(func(xi, yi int) color.Color {
-				x := float64(xi) + 0.5
-				y := float64(yi) + 0.5
-				dx := x - cx
-				dy := y - cy
-				return g.tColor(math.Sqrt(dx*dx/(rx*rx)+dy*dy/(ry*ry)), opacity)
-			})
+			if g.Units == ObjectBoundingBox {
+				return ColorFunc(func(xi, yi int) color.Color {
+					x, y := gradT.Transform(float64(xi)+0.5, float64(yi)+0.5)
+					dx := float64(x) - cx
+					dy := float64(y) - cy
+					return g.tColor(math.Sqrt(dx*dx/(rx*rx)+dy*dy/(ry*ry)), opacity)
+				})
+			} else {
+				return ColorFunc(func(xi, yi int) color.Color {
+					x := float64(xi) + 0.5
+					y := float64(yi) + 0.5
+					dx := x - cx
+					dy := y - cy
+					return g.tColor(math.Sqrt(dx*dx/(rx*rx)+dy*dy/(ry*ry)), opacity)
+				})
+			}
 		} else {
 			fx /= rx
 			fy /= ry
@@ -207,25 +219,46 @@ func (g *Gradient) GetColorFunction(opacity float64, objMatrix Matrix2D) interfa
 					return color.RGBA{255, 255, 0, 255} // should not happen
 				}
 			}
-			return ColorFunc(func(xi, yi int) color.Color {
-				x := float64(xi) + 0.5
-				y := float64(yi) + 0.5
-				ex := x / rx
-				ey := y / ry
+			if g.Units == ObjectBoundingBox {
+				return ColorFunc(func(xi, yi int) color.Color {
+					x, y := gradT.Transform(float64(xi)+0.5, float64(yi)+0.5)
+					ex := x / rx
+					ey := y / ry
 
-				t1x, t1y, intersects := RayCircleIntersectionF(ex, ey, fx, fy, cx, cy, 1.0)
-				if intersects == false { //In this case, use the last stop color
-					s := g.Stops[len(g.Stops)-1]
-					return ApplyOpacity(s.StopColor, s.Opacity*opacity)
-				}
-				tdx, tdy := t1x-fx, t1y-fy
-				dx, dy := ex-fx, ey-fy
-				if tdx*tdx+tdy*tdy < epsilonF {
-					s := g.Stops[len(g.Stops)-1]
-					return ApplyOpacity(s.StopColor, s.Opacity*opacity)
-				}
-				return g.tColor(math.Sqrt(dx*dx+dy*dy)/math.Sqrt(tdx*tdx+tdy*tdy), opacity)
-			})
+					t1x, t1y, intersects := RayCircleIntersectionF(ex, ey, fx, fy, cx, cy, 1.0)
+					if intersects == false { //In this case, use the last stop color
+						s := g.Stops[len(g.Stops)-1]
+						return ApplyOpacity(s.StopColor, s.Opacity*opacity)
+					}
+					tdx, tdy := t1x-fx, t1y-fy
+					dx, dy := ex-fx, ey-fy
+					if tdx*tdx+tdy*tdy < epsilonF {
+						s := g.Stops[len(g.Stops)-1]
+						return ApplyOpacity(s.StopColor, s.Opacity*opacity)
+					}
+					return g.tColor(math.Sqrt(dx*dx+dy*dy)/math.Sqrt(tdx*tdx+tdy*tdy), opacity)
+				})
+			} else {
+				return ColorFunc(func(xi, yi int) color.Color {
+					x := float64(xi) + 0.5
+					y := float64(yi) + 0.5
+					ex := x / rx
+					ey := y / ry
+
+					t1x, t1y, intersects := RayCircleIntersectionF(ex, ey, fx, fy, cx, cy, 1.0)
+					if intersects == false { //In this case, use the last stop color
+						s := g.Stops[len(g.Stops)-1]
+						return ApplyOpacity(s.StopColor, s.Opacity*opacity)
+					}
+					tdx, tdy := t1x-fx, t1y-fy
+					dx, dy := ex-fx, ey-fy
+					if tdx*tdx+tdy*tdy < epsilonF {
+						s := g.Stops[len(g.Stops)-1]
+						return ApplyOpacity(s.StopColor, s.Opacity*opacity)
+					}
+					return g.tColor(math.Sqrt(dx*dx+dy*dy)/math.Sqrt(tdx*tdx+tdy*tdy), opacity)
+				})
+			}
 		}
 	} else {
 		p1x, p1y, p2x, p2y := g.Points[0], g.Points[1], g.Points[2], g.Points[3]
@@ -234,24 +267,31 @@ func (g *Gradient) GetColorFunction(opacity float64, objMatrix Matrix2D) interfa
 			p1y = g.Bounds.Y + g.Bounds.H*p1y
 			p2x = g.Bounds.X + g.Bounds.W*p2x
 			p2y = g.Bounds.Y + g.Bounds.H*p2y
-			p1x, p1y = g.Matrix.Transform(p1x, p1y)
-			p2x, p2y = g.Matrix.Transform(p2x, p2y)
+
+			dx := p2x - p1x
+			dy := p2y - p1y
+			d := (dx*dx + dy*dy) // self inner prod
+			return ColorFunc(func(xi, yi int) color.Color {
+				x, y := gradT.Transform(float64(xi)+0.5, float64(yi)+0.5)
+				dfx := x - p1x
+				dfy := y - p1y
+				return g.tColor((dx*dfx+dy*dfy)/d, opacity)
+			})
 		} else {
 			p1x, p1y = g.Matrix.Transform(p1x, p1y)
 			p2x, p2y = g.Matrix.Transform(p2x, p2y)
 			p1x, p1y = objMatrix.Transform(p1x, p1y)
 			p2x, p2y = objMatrix.Transform(p2x, p2y)
+			dx := p2x - p1x
+			dy := p2y - p1y
+			d := (dx*dx + dy*dy) // self inner prod
+			return ColorFunc(func(xi, yi int) color.Color {
+				x := float64(xi) + 0.5
+				y := float64(yi) + 0.5
+				dfx := x - p1x
+				dfy := y - p1y
+				return g.tColor((dx*dfx+dy*dfy)/d, opacity)
+			})
 		}
-
-		dx := p2x - p1x
-		dy := p2y - p1y
-		d := (dx*dx + dy*dy) // self inner prod
-		return ColorFunc(func(xi, yi int) color.Color {
-			x := float64(xi) + 0.5
-			y := float64(yi) + 0.5
-			dfx := x - p1x
-			dfy := y - p1y
-			return g.tColor((dx*dfx+dy*dfy)/d, opacity)
-		})
 	}
 }

--- a/matrix.go
+++ b/matrix.go
@@ -92,6 +92,12 @@ func (m Matrix2D) Transform(x1, y1 float64) (x2, y2 float64) {
 	return
 }
 
+func (m Matrix2D) TransformVector(x1, y1 float64) (x2, y2 float64) {
+	x2 = x1*m.A + y1*m.C
+	y2 = x1*m.B + y1*m.D
+	return
+}
+
 func (a Matrix2D) Scale(x, y float64) Matrix2D {
 	return a.Mult(Matrix2D{
 		A: x,

--- a/rasterx_test.go
+++ b/rasterx_test.go
@@ -332,13 +332,13 @@ func TestGradient(t *testing.T) {
 
 	p.AddTo(offsetPath)
 
-	scannerGV.SetColor(radialGradient.GetColorFunction(1))
+	scannerGV.SetColor(radialGradient.GetColorFunction(1, Identity))
 	f.Draw()
 	f.Clear()
 
 	scannerGV.SetClip(image.Rect(420, 350, 460, 400))
 	offsetPath.M = Identity.Translate(340, 180)
-	scannerGV.SetColor(radialGradient.GetColorFunction(1))
+	scannerGV.SetColor(radialGradient.GetColorFunction(1, Identity))
 	p.AddTo(offsetPath)
 	f.Draw()
 	f.Clear()
@@ -348,7 +348,7 @@ func TestGradient(t *testing.T) {
 	f.Draw()
 	f.Clear()
 
-	scannerGV.SetColor(linearGradient.GetColorFunction(1.0))
+	scannerGV.SetColor(linearGradient.GetColorFunction(1.0, Identity))
 	p.AddTo(f)
 	f.Draw()
 	f.Clear()


### PR DESCRIPTION
tested that that this still reproduces same results on the test data and it also works for my test cases of the UserSpaceOnUse version.  For oksvg to support this, it would need to be able to read in points as either %'s or raw numbers, and not force them to max out at 1.  It also needs to pass in the object transform.