### PR TITLE
fix loss of precision in ToLength

### DIFF
--- a/geomx.go
+++ b/geomx.go
@@ -155,8 +155,13 @@ func ToLength(p fixed.Point26_6, ln fixed.Int26_6) (q fixed.Point26_6) {
 	if ln == 0 || (p.X == 0 && p.Y == 0) {
 		return
 	}
-	lp := Length(p)
-	q.X, q.Y = p.X*ln/lp, p.Y*ln/lp
+
+	pX, pY := float64(p.X), float64(p.Y)
+	lnF := float64(ln)
+	pLen := math.Sqrt(pX*pX + pY*pY)
+
+	qX, qY := pX*lnF/pLen, pY*lnF/pLen
+	q.X, q.Y = fixed.Int26_6(qX), fixed.Int26_6(qY)
 	return
 }
 

--- a/rasterx_test.go
+++ b/rasterx_test.go
@@ -329,6 +329,17 @@ func TestGeom(t *testing.T) {
 	}
 }
 
+func TestToLength(t *testing.T) {
+        p := fixed.Point26_6{X: 2, Y: -2}
+        ln := fixed.I(40)
+
+        q := ToLength(p, ln)
+        expected := fixed.Point26_6{X: 1810, Y: -1810}
+        if q != expected {
+                t.Error("wrong point", q)
+        }
+}
+
 func TestShapes(t *testing.T) {
 	var (
 		wx, wy = 512, 512


### PR DESCRIPTION
This fixes
https://github.com/srwiley/scanFT/issues/1